### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-004.students.flatironschool.com


### PR DESCRIPTION
It is about time we upgrade due to GitHub Pages! If students try to deploy their work with an existing CNAME, it won't be actually accessible for anyone. I don't know if we have the ability to put them as subdomains for flatiron school, but that would be rad.

Hopefully fixes #90. Shoutout to @realAndrewCohn 